### PR TITLE
Raise error duplicate role

### DIFF
--- a/lib/server_settings.rb
+++ b/lib/server_settings.rb
@@ -9,11 +9,15 @@ require "server_settings/role_db"
 class ServerSettings
   attr_accessor :roles
 
+  ## Exceptions
+  class DuplicateRole < StandardError; end
+
   def initialize
     @roles = {}
   end
 
   def << (role)
+    raise DuplicateRole, "`#{role.name}' already defined" if @roles.has_key?(role.name)
     @roles[role.name] = role
   end
 

--- a/spec/servers_config_spec.rb
+++ b/spec/servers_config_spec.rb
@@ -23,6 +23,10 @@ role2:
 EOF
   }
 
+  after do
+    ServerSettings.destroy
+  end
+
   describe "config_load" do
     before do
       filepath = "config.yml"
@@ -34,23 +38,15 @@ EOF
       ServerSettings.load_config("config.yml")
     end
 
-    it 'can override role by another config' do
-
-      ServerSettings.load_config("config.yml")
-      expect(ServerSettings.role2.hosts.with_format("%host")).to eq(["3.3.3.3"])
-      allow(IO).to receive(:read).with("config2.yml").and_return(config2)
-      allow(File).to receive(:mtime).with("config2.yml").and_return(Time.now)
-
-      # load again
-      ServerSettings.load_config("config2.yml")
-      expect(ServerSettings.role2.hosts.with_format("%host")).to eq(["4.4.4.4"])
+    it 'raise error when found duplicate role' do
+      ServerSettings.load_from_yaml("role1: { hosts: [ 1.1.1.1 ] }")
+      expect do
+        ServerSettings.load_from_yaml("role1: { hosts: [ 2.2.2.2 ] }")
+      end.to raise_error(ServerSettings::DuplicateRole)
     end
 
     ## TODO check invalid yaml
 
-    after do
-      ServerSettings.destroy
-    end
   end
 
   describe "load_config_dir" do


### PR DESCRIPTION
https://github.com/monsterstrike/server_settings/issues/11

Raise error when role definition overrided by another yaml file.
