### PR TITLE
Add ServerSettings::Database and db iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,29 @@ databases:
       :master: 192.168.30.86
       :backup: 192.168.30.85
 ```
-
+#### Access DB configuration
 ```ruby
 ServerSettings.load_config("config/production/server-config.yaml")
 
 ServerSettings.database.find("db1").config(:master)
 # => {:adapter=>"mysql2", :encoding=>"utf8", :reconnect=>true, :database=>"app_db1", :pool=>10, :username=>"db_user1", :password=>"db_pass1", :host=>"192.168.30.86"}
+ServerSettings.database.find("db1").config(:backup)
+# => {:adapter=>"mysql2", :encoding=>"utf8", :reconnect=>true, :database=>"app_db1", :pool=>10, :username=>"db_user1", :password=>"db_pass1", :host=>"192.168.30.85"}
+ServerSettings.database.find("db1").config(:slaves)
+# =>[ {:adapter=>"mysql2", :encoding=>"utf8", :reconnect=>true, :database=>"app_db1", :pool=>10, :username=>"db_user1", :password=>"db_pass1", :host=>"192.168.30.87"},
+# {:adapter=>"mysql2", :encoding=>"utf8", :reconnect=>true, :database=>"app_db1", :pool=>10, :username=>"db_user1", :password=>"db_pass1", :host=>"192.168.30.88"}]
+```
+#### Iterator for all db config
+```ruby
+ServerSettings.load_config("config/production/server-config.yaml")
+
+ServerSettings.database.each do |db|
+  db.master      # => 192.168.30.86
+  db.backup      # => 192.168.30.85
+  db.slaves      # => [ 192.168.30.87, 192.168.30.88 ]
+  db.has_slave?  # => true
+  db.settings    # => {:adapter=>"mysql2", :encoding=>"utf8", :reconnect=>true, :database=>"app_db1", :pool=>10, :username=>"db_user1", :password=>"db_pass1"}
+end
 ```
 
 ### For Capistrano

--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ databases:
 ```ruby
 ServerSettings.load_config("config/production/server-config.yaml")
 
-ServerSettings.database.find("db1").config(:master)
+ServerSettings.databases.find("db1").config(:master)
 # => {:adapter=>"mysql2", :encoding=>"utf8", :reconnect=>true, :database=>"app_db1", :pool=>10, :username=>"db_user1", :password=>"db_pass1", :host=>"192.168.30.86"}
-ServerSettings.database.find("db1").config(:backup)
+ServerSettings.databases.find("db1").config(:backup)
 # => {:adapter=>"mysql2", :encoding=>"utf8", :reconnect=>true, :database=>"app_db1", :pool=>10, :username=>"db_user1", :password=>"db_pass1", :host=>"192.168.30.85"}
-ServerSettings.database.find("db1").config(:slaves)
+ServerSettings.databases.find("db1").config(:slaves)
 # =>[ {:adapter=>"mysql2", :encoding=>"utf8", :reconnect=>true, :database=>"app_db1", :pool=>10, :username=>"db_user1", :password=>"db_pass1", :host=>"192.168.30.87"},
 # {:adapter=>"mysql2", :encoding=>"utf8", :reconnect=>true, :database=>"app_db1", :pool=>10, :username=>"db_user1", :password=>"db_pass1", :host=>"192.168.30.88"}]
 ```
@@ -125,7 +125,7 @@ ServerSettings.database.find("db1").config(:slaves)
 ```ruby
 ServerSettings.load_config("config/production/server-config.yaml")
 
-ServerSettings.database.each do |db|
+ServerSettings.databases.each do |db|
   db.master      # => 192.168.30.86
   db.backup      # => 192.168.30.85
   db.slaves      # => [ 192.168.30.87, 192.168.30.88 ]

--- a/README.md
+++ b/README.md
@@ -86,30 +86,35 @@ instend of Array.
 Resque.redis = ServerSettings.redis_endpoint.with_format("%host:%port")
 
 ```
-### For ActiveRecord DB
+### For DB
 
 ```yaml
-database:
+databases:
   :adapter: mysql2
   :encoding: utf8
   :reconnect: true
-  :database: dbname-master
-  :pool: 1
-  :username: user
-  :password: pass
-  :host: 192.168.100.1
-  master:
-    :host: 192.168.100.2
-  user:
-    :database: dbname-user
-    :host: 192.168.100.3
-
+  :database: app
+  :pool: 10
+  :username: db_user1
+  :password: db_pass1
+  :master: 192.168.30.86
+  :backup: 192.168.30.85
+  db1:
+    :database: app_db1
+    :master: 192.168.30.86
+    :backup: 192.168.30.85
+    :slaves: [  192.168.30.87, 192.168.30.88 ]
+  group1:
+    db2:
+      :master: 192.168.30.86
+      :backup: 192.168.30.85
 ```
 
 ```ruby
 ServerSettings.load_config("config/production/server-config.yaml")
 
-ActiveRecord::Base.configurations[:development]  = ServerSettings.database.configurations
+ServerSettings.database.find("db1").config(:master)
+# => {:adapter=>"mysql2", :encoding=>"utf8", :reconnect=>true, :database=>"app_db1", :pool=>10, :username=>"db_user1", :password=>"db_pass1", :host=>"192.168.30.86"}
 ```
 
 ### For Capistrano

--- a/lib/server_settings.rb
+++ b/lib/server_settings.rb
@@ -5,6 +5,7 @@ require "server_settings/host"
 require "server_settings/host_collection"
 require "server_settings/role"
 require "server_settings/role_db"
+require "server_settings/database"
 
 class ServerSettings
   attr_accessor :roles

--- a/lib/server_settings/database.rb
+++ b/lib/server_settings/database.rb
@@ -1,0 +1,24 @@
+class ServerSettings
+  class Database
+    attr_accessor :name, :group, :master, :backup, :slaves, :settings
+    def initialize(name, group)
+      @name = name
+      @group = group
+    end
+
+    def config(role)
+      host = send(role)
+      if host.kind_of?(Array)
+        host.map { |h| settings.merge(:host => h) }
+      elsif host.kind_of?(String)
+        settings.merge(:host => host)
+      else
+        nil
+      end
+    end
+
+    def has_slave?
+      !! @slaves and not @slaves.empty?
+    end
+  end
+end

--- a/lib/server_settings/database.rb
+++ b/lib/server_settings/database.rb
@@ -18,6 +18,10 @@ class ServerSettings
       end
     end
 
+    def host
+      @master
+    end
+
     def has_slave?
       !! @slaves and not @slaves.empty?
     end

--- a/lib/server_settings/database.rb
+++ b/lib/server_settings/database.rb
@@ -8,9 +8,10 @@ class ServerSettings
 
     def config(role)
       host = send(role)
-      if host.kind_of?(Array)
+      case host
+      when Array
         host.map { |h| settings.merge(:host => h) }
-      elsif host.kind_of?(String)
+      when String
         settings.merge(:host => host)
       else
         nil

--- a/lib/server_settings/role_db.rb
+++ b/lib/server_settings/role_db.rb
@@ -44,7 +44,7 @@ class ServerSettings
     end
 
     def hosts
-      map { |db| db }
+      find_all
     end
 
     def config_params(config)

--- a/lib/server_settings/role_db.rb
+++ b/lib/server_settings/role_db.rb
@@ -44,7 +44,7 @@ class ServerSettings
     end
 
     def hosts
-      each { |db| db.master }.flatten
+      map { |db| db.master }.flatten.uniq
     end
 
     def config_params(config)

--- a/lib/server_settings/role_db.rb
+++ b/lib/server_settings/role_db.rb
@@ -1,42 +1,82 @@
 class ServerSettings
+  class Database
+    attr_accessor :name, :group, :master, :backup, :slaves, :settings
+    def initialize(name, group)
+      @name = name
+      @group = group
+    end
+
+    def config(role)
+      host = send(role)
+      if host.kind_of?(Array)
+        host.map { |h| settings.merge(:host => h) }
+      elsif host.kind_of?(String)
+        settings.merge(:host => host)
+      else
+        nil
+      end
+    end
+
+    def has_slave?
+      !! @slaves and not @slaves.empty?
+    end
+  end
+
   class RoleDB < Role
+    include Enumerable
+    attr_accessor :is_group
 
     def databases
       @config.keys.select { |a| a.kind_of?(String) }
     end
 
-    def db_config_each
-      databases.map do |db|
-        config = @config[db]
-        if config && config.has_key?(:host)
-          yield(config)
-        else
-          config.map do |nest_db, nest_config|
-            yield(nest_config)
+    def build_db(name, config, group = nil)
+      db = Database.new(name, group)
+      db.master = config[:master]
+      db.backup = config[:backup]
+      db.slaves = config[:slaves]
+      db.settings = config_params(config)
+      return db
+    end
+
+    def find(db_name)
+      select { |s| s.name == db_name }.first
+    end
+
+    def each
+      default_db = build_db("default", @config)
+      yield default_db
+
+      databases.each do |db_name|
+        config = @config[db_name]
+
+        if config && config.has_key?(:master)
+          db = build_db(db_name, config)
+          db.settings = default_db.settings.merge(db.settings)
+          yield db
+
+        else # this is group section
+          group_name = db_name
+          config.map do |nest_db_name, nest_config|
+            db = build_db(nest_db_name, nest_config, group_name)
+            db.settings = default_db.settings.merge(db.settings)
+            yield db
           end
         end
       end
     end
 
     def hosts
-      db_config_each do |config|
-        config[:host]
-      end.flatten
+      each { |db| db.master }.flatten
     end
 
-    # database.rb data strcutre
-    def configurations
-      parent_config_keys = @config.keys.select {|s| s.is_a?(Symbol)}
-      parent_config = Hash[*parent_config_keys.map {|s| [s, @config[s]] }.flatten]
-      db_config_each do |config|
-        parent_config.each do |key,value|
-          next if config.has_key?(key)
-          config[key] = value
-        end
+    def config_params(config)
+      exclude_settings = [ :master, :backup, :slaves ]
+      config_keys = config.keys.select do |s|
+        s.is_a?(Symbol) and not exclude_settings.include?(s)
       end
-      return @config
+      Hash[*config_keys.map {|s| [s, config[s]] }.flatten]
     end
 
   end
 end
-

--- a/lib/server_settings/role_db.rb
+++ b/lib/server_settings/role_db.rb
@@ -1,30 +1,7 @@
 class ServerSettings
-  class Database
-    attr_accessor :name, :group, :master, :backup, :slaves, :settings
-    def initialize(name, group)
-      @name = name
-      @group = group
-    end
-
-    def config(role)
-      host = send(role)
-      if host.kind_of?(Array)
-        host.map { |h| settings.merge(:host => h) }
-      elsif host.kind_of?(String)
-        settings.merge(:host => host)
-      else
-        nil
-      end
-    end
-
-    def has_slave?
-      !! @slaves and not @slaves.empty?
-    end
-  end
 
   class RoleDB < Role
     include Enumerable
-    attr_accessor :is_group
 
     def databases
       @config.keys.select { |a| a.kind_of?(String) }

--- a/lib/server_settings/role_db.rb
+++ b/lib/server_settings/role_db.rb
@@ -44,7 +44,7 @@ class ServerSettings
     end
 
     def hosts
-      map { |db| db.master }.flatten.uniq
+      map { |db| db }
     end
 
     def config_params(config)

--- a/spec/servers_config_spec.rb
+++ b/spec/servers_config_spec.rb
@@ -243,9 +243,9 @@ EOS
     end
 
     describe "hosts" do
-      it 'can iterate each server' do
+      it 'return array of db instance' do
         ServerSettings.load_from_yaml(db_config)
-        expect(ServerSettings.databases.hosts).to eq(["192.168.30.86"])
+        expect(ServerSettings.databases.hosts).to include(instance_of(ServerSettings::Database))
       end
     end
 

--- a/spec/servers_config_spec.rb
+++ b/spec/servers_config_spec.rb
@@ -128,4 +128,75 @@ EOF
       expect(ServerSettings.role.hosts.first.host).to eq("4.4.4.4")
     end
   end
+
+  describe 'databases' do
+    let (:db_config)  { <<EOS }
+databases:
+  :adapter: mysql2
+  :encoding: utf8
+  :reconnect: true
+  :database: app
+  :pool: 10
+  :username: db_user1
+  :password: db_pass1
+  :master: 192.168.30.86
+  :backup: 192.168.30.85
+  db1:
+    :database: app_db1
+    :master: 192.168.30.86
+    :backup: 192.168.30.85
+  shards:
+    user_shard_1:
+      :database: app_user_shard1
+      :master: 192.168.30.86
+      :backup: 192.168.30.85
+    user_shard_2:
+      :database: app_user_shard2
+      :master: 192.168.30.86
+      :backup: 192.168.30.85
+  db2:
+    :database: app_db2
+    :master: 192.168.30.86
+    :backup: 192.168.30.85
+    :slaves: [  192.168.30.87, 192.168.30.88 ]
+  group1:
+    db3:
+      :master: 192.168.30.86
+      :backup: 192.168.30.85
+EOS
+    describe ServerSettings::Database do
+      context "db in group" do
+        it 'return db instance ' do
+          ServerSettings.load_from_yaml(db_config)
+        end
+      end
+    end
+
+    describe "find" do
+      it 'return db instance ' do
+        ServerSettings.load_from_yaml(db_config)
+        db1 = ServerSettings.databases.find("db1")
+        expect(db1.master).to eq("192.168.30.86")
+        expect(db1.backup).to eq("192.168.30.85")
+        expect(db1.settings[:database]).to eq("app_db1")
+        expect(db1.settings[:username]).to eq("db_user1")
+      end
+
+      it 'return nil if not found' do
+        ServerSettings.load_from_yaml(db_config)
+        db = ServerSettings.databases.find("not-found")
+        expect(db).to be_nil
+      end
+    end
+
+
+    describe "each" do
+      it 'loop 6 times yield with db argument' do
+        ServerSettings.load_from_yaml(db_config)
+        args = 6.times.map {ServerSettings::Database}
+        expect { |b| ServerSettings.databases.each(&b)}.to yield_control.exactly(6).times
+        expect { |b| ServerSettings.databases.each(&b)}.to yield_successive_args(*args)
+      end
+    end
+  end
 end

--- a/spec/servers_config_spec.rb
+++ b/spec/servers_config_spec.rb
@@ -242,6 +242,13 @@ EOS
 
     end
 
+    describe "hosts" do
+      it 'can iterate each server' do
+        ServerSettings.load_from_yaml(db_config)
+        expect(ServerSettings.databases.hosts).to eq(["192.168.30.86"])
+      end
+    end
+
     describe "find" do
       it 'return db instance ' do
         ServerSettings.load_from_yaml(db_config)


### PR DESCRIPTION
- データベースの構成情報をyamlに記述できるようにした(master,backup,slave)
- DB設定クラスを用意
- `ServerSettings.databases.each`を使って、書くDB設定インスタンスへアクセスできる
