### PR TITLE
Stringify config keys on Rails

### DIFF
--- a/lib/server_settings/database_config.rb
+++ b/lib/server_settings/database_config.rb
@@ -11,28 +11,36 @@ class ServerSettings
       ServerSettings.databases.each do |db|
         next unless db.config(db_role)
 
+        db_config = db.config(db_role)
+        stringify_keys!(db_config) if defined? Rails
+
         if db.name == "default"
           if defined? Rails
-            configuration[Rails.env] = db.config(db_role)
+            configuration[Rails.env] = db_config
           else
-            configuration.merge!(db.config(db_role))
+            configuration.merge!(db_config)
           end
         elsif db.group
           configuration[db.group] ||= {}
-          configuration[db.group][db.name] = db.config(db_role)
+          configuration[db.group][db.name] = db_config
         else
-          configuration[db.name] = db.config(db_role)
+          configuration[db.name] = db_config
         end
 
         if with_slave && db.has_slave?
           db.config(:slaves).each.with_index(1) do |config, idx|
             # スレーブのバックアップホストは、マスターのバックアップホストと同じにする
             config[:host] = db.backup if db_role == :backup
+            stringify_keys!(config) if defined? Rails
             configuration[slave_name(db.name, idx)] = config
           end
         end
       end
       configuration
+    end
+
+    def self.stringify_keys!(config)
+      config.keys.each { |key| config[key.to_s] = config.delete(key) }
     end
   end
 end

--- a/spec/lib/server_settings/database_config_spec.rb
+++ b/spec/lib/server_settings/database_config_spec.rb
@@ -87,6 +87,11 @@ EOF
         database_config = ServerSettings::DatabaseConfig.generate_database_config(:master)
         expect(database_config["test"]).not_to eq nil
       end
+      it "returns configs with string keys" do
+        database_config = ServerSettings::DatabaseConfig.generate_database_config(:master)
+        expect(database_config["user"].keys.all? { |k| k.is_a? String }).to be true
+        expect(database_config["has_slave_slave1"].keys.all? { |k| k.is_a? String }).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
Railsで使用する場合、configの各キーを文字列にして返すようにします。
DatabaseRewinderで一部、文字列じゃないといけない箇所があるため。