### PR TITLE
Remove splat operator in 'load_servers' for capistrano3

### DIFF
--- a/lib/capistrano/server_settings.rb
+++ b/lib/capistrano/server_settings.rb
@@ -3,6 +3,6 @@ require 'server_settings'
 def load_servers(pattern)
   ServerSettings.load_config_dir(pattern)
   ServerSettings.each_role do |role, hosts|
-    role role.to_sym, *hosts.map(&:host)
+    role role.to_sym, hosts.map(&:host)
   end
 end


### PR DESCRIPTION
`role` method accepts only two arguments in capistrano 3.